### PR TITLE
Added wildcard explanation

### DIFF
--- a/docs/ArgumentsTestResultsFile.md
+++ b/docs/ArgumentsTestResultsFile.md
@@ -2,7 +2,9 @@
 
 ## Explanation
 
-Path to the XML results file
+Path to the XML results file. The filename itself can be a wildcard as defined by the [searchpattern of the .NET Directory.GetFiles() method](https://msdn.microsoft.com/en-us/library/wz42302f(v=vs.110).aspx?f=255&mspperror=-2147217396#Anchor_2).
+
+For selecting multiple resultsfiles to be processed, you can use the wildcard searchpattern, you can enter the files as a semicolon separated list or a combination of both. Selecting only a path to a folder will not work, when all files in a folder needs to be selected, append a * to the path.
 
 ## Default Value
 
@@ -10,7 +12,7 @@ None.
 
 ## Possible Values
 
-Any path to a valid results file in XML format.
+Any path(s) or patterns for a results file in XML format as long as it results in at least one match to a valid file. 
 
 ## Usage
 
@@ -19,6 +21,10 @@ Any path to a valid results file in XML format.
 	Pickles.exe --link-results-file=C:\MyProject\Reports\results.xml
 
 	Pickles.exe -lr=C:\MyProject\Reports\results.xml
+	
+	Pickles.exe -lr=C:\MyProject\Reports\*.xml
+	
+	Pickles.exe -lr=C:\MyProject\UnitTest\results.xml;C:\MyProject\SystemTest\*
 
 ### Powershell
 


### PR DESCRIPTION
With #435 it is possible to use wildcards and/or lists to filepaths for test result files. The documentation is now reflecting these added features.